### PR TITLE
Fix server-side rendering.

### DIFF
--- a/src/foam/dom.clj
+++ b/src/foam/dom.clj
@@ -163,7 +163,7 @@
 
 (defn render-attr-map [attrs]
   (apply str
-         (clojure.core/map render-attribute (sort-by key attrs))))
+         (clojure.core/map render-attribute attrs)))
 
 (defn render-inner [attrs children]
   (if (:dangerouslySetInnerHTML attrs)
@@ -189,12 +189,16 @@
 
 (defn render-element
   "Render an tag vector as a HTML element string."
-  [{:keys [tag attrs children]}]
-  (if (container-tag? tag (seq children))
-    (str "<" tag (render-attr-map attrs) ">"
-         (render-inner attrs children)
-         "</" tag ">")
-    (str "<" tag (render-attr-map attrs) ">")))
+  [{:keys [tag attrs react-id children]}]
+  (let [html 
+    (str "<" tag
+        (render-attr-map attrs) 
+        (when react-id 
+            (str " data-reactid=\"" (react-id-str react-id) "\""))
+        ">")]
+    (if (container-tag? tag (seq children))
+        (str html (render-inner attrs children) "</" tag ">")
+        html)))
 
 (defrecord Element [tag attrs react-id children]
   foam/ReactRender
@@ -289,7 +293,31 @@
    (let [elem (assoc elem :react-id id)]
      (update-in elem [:children] (fn [children]
                                    (map-indexed (fn [i c]
-                                                  (assign-react-ids c (conj id i))) children))))))
+                                                  (let [current-part (Integer/toString i 30)]
+                                                      (assign-react-ids c (conj id current-part)))) children))))))
+
+(def mod-number 65521)
+
+(defn react-adler32* [data max-index a b i]
+  (if (= max-index i)
+    (bit-or a (clojure.lang.Numbers/shiftLeftInt b 16))
+    (let [a (mod (+ a (Character/codePointAt data i)) mod-number)
+          b (mod (+ a b) mod-number)]
+      (recur data max-index a b (inc i)))))
+
+
+(defn react-adler32 [data]
+  (react-adler32* data (count data) 1 0 0))
+
+
+(defn add-checksum-to-markup [markup]
+  (let [checksum (react-adler32 markup)]
+    (str/replace-first markup ">" (str " " "data-react-checksum" "=\"" checksum "\">"))
+  ))
+
 (defn render-to-string [com]
-  (let [elem (foam/react-render com)]
-    (foam/-render-to-string elem)))
+  (-> com
+    (foam/react-render)
+    (assign-react-ids)
+    (foam/-render-to-string)
+    (add-checksum-to-markup)))

--- a/src/foam/dom.clj
+++ b/src/foam/dom.clj
@@ -285,6 +285,15 @@
 
 (def-all-tags)
 
+(declare assign-react-ids)
+
+(defn determine-react-id [index element parent-id]
+  (if (associative? element)
+    (let [current-part (Integer/toString index 30)]
+      (assign-react-ids element (conj parent-id current-part)))
+    element))
+
+
 (defn assign-react-ids
   ([elem]
    (assign-react-ids elem [0]))
@@ -292,9 +301,7 @@
    (assert (vector? id))
    (let [elem (assoc elem :react-id id)]
      (update-in elem [:children] (fn [children]
-                                   (map-indexed (fn [i c]
-                                                  (let [current-part (Integer/toString i 30)]
-                                                      (assign-react-ids c (conj id current-part)))) children))))))
+                                   (map-indexed (fn [index element] (determine-react-id index element id)) children))))))
 
 (def mod-number 65521)
 

--- a/test/foam/html_test.clj
+++ b/test/foam/html_test.clj
@@ -81,4 +81,4 @@
         cursor (foam/root-cursor state)
         com (foam/build inner-html-and-classname-component cursor {})
         com-string (dom/render-to-string com)]
-    (is (= com-string "<p class=\"some-class\"><span>Some inline text</span> and more text</p>"))))
+    (is (= com-string "<p class=\"some-class\" data-reactid=\".0\" data-react-checksum=\"577707518\"><span>Some inline text</span> and more text</p>"))))


### PR DESCRIPTION
React was not picking up the markup because it had no data-reactids and it
had no checksum. The markup itself was different too, since the attributes
were being sorted alphabetically (React/om don't do this). These changes make
the "React attempted to reuse markup but..." message on the console
disappear.
